### PR TITLE
Update markdown

### DIFF
--- a/markdown/errors-and-warnings.md
+++ b/markdown/errors-and-warnings.md
@@ -8,7 +8,7 @@ This warning is caused, because the script is not able to find your pyheif insta
 Without pyheif, the converter won't be able to convert from heif file format.
 <br/><br/><b>How to solve?</b><br/>
 To solve this warning, you need to install pyheif using pip.
-View the [Optional dependencies](https://github.com/Lich-Corals/linux-file-converter-addon/blob/main/markdown/install-dependencies.md#optional-dependencies) section to get installation instructions.
+<br/>View the [Optional dependencies](https://github.com/Lich-Corals/linux-file-converter-addon/blob/main/markdown/install-dependencies.md#optional-dependencies) section to get installation instructions.
 
 ### (001): "jxlpy" not found
 <b>Causes:</b><br/>

--- a/markdown/install-nemo.md
+++ b/markdown/install-nemo.md
@@ -18,14 +18,18 @@ sudo pacman -S nemo
 - Download the nautilus-fileconverter.py and the nautilus-fileconverter.nemo_action file from the [release page](https://github.com/Lich-Corals/linux-file-converter-addon/releases).
     - Git users can also get the repository with these commands[:](https://bit.ly/3BlS71b)
      ```bash
-        git clone https://github.com/Lich-Corals/linux-file-converter-addon
+     git clone https://github.com/Lich-Corals/linux-file-converter-addon
 
-        cd ./linux-file-converter-addon
+     cd ./linux-file-converter-addon
      ```
 - Copy the files into the ~/.local/share/nemo/actions folder:
      ```bash
-        mv nautilus-fileconverter.py ~/.local/share/nemo/actions/nautilus-fileconverter.py
-        mv nautilus-fileconverter.nemo_action ~/.local/share/nemo/actions/nautilus-fileconverter.nemo_action
+     mv nautilus-fileconverter.py ~/.local/share/nemo/actions/nautilus-fileconverter.py
+     mv nautilus-fileconverter.nemo_action ~/.local/share/nemo/actions/nautilus-fileconverter.nemo_action
+     ```
+- Give the script permission to be executed as script:
+     ```bash
+     chmod +x nautilus-fileconverter.py
      ```
  You may need to enable the action in Nemo's settings. To do so, you can open Nemo and go edit>Plugins (or press Alt+P) and check the checkbox labelled with "Convert to..." in the "Actions" area.
 


### PR DESCRIPTION
- Add a missing step to the nemo-install file.
- Add a \<br/> to make the style of an error match the same as the other ones in the warnings-and-errors file.
